### PR TITLE
Add additional macro expansion tests

### DIFF
--- a/Tests/DefaultCodableTests/DefaultCodableTests.swift
+++ b/Tests/DefaultCodableTests/DefaultCodableTests.swift
@@ -81,4 +81,80 @@ final class DefaultCodableTests: XCTestCase {
             throw XCTSkip("macros are only supported when running tests for the host platform")
         #endif
     }
+
+    func testLiteralTypeInference() throws {
+        #if canImport(DefaultCodableMacros)
+            assertMacroExpansion(
+                """
+                @DefaultCodable
+                struct Foo: Codable {
+                    var flag = true
+                    var count = 5
+                    var ratio = 1.5
+                    var message = "hi"
+                }
+                """,
+                expandedSource: """
+                struct Foo: Codable {
+                    var flag = true
+                    var count = 5
+                    var ratio = 1.5
+                    var message = "hi"
+
+                    enum CodingKeys: String, CodingKey {
+                        case flag
+                        case count
+                        case ratio
+                        case message
+                    }
+
+                    init(from decoder: Decoder) throws {
+                        let container = try decoder.container(keyedBy: CodingKeys.self)
+                        self.flag = try container.decodeIfPresent(Bool.self, forKey: .flag) ?? true
+                        self.count = try container.decodeIfPresent(Int.self, forKey: .count) ?? 5
+                        self.ratio = try container.decodeIfPresent(Double.self, forKey: .ratio) ?? 1.5
+                        self.message = try container.decodeIfPresent(String.self, forKey: .message) ?? "hi"
+                    }
+                }
+                """,
+                macros: testMacros
+            )
+        #else
+            throw XCTSkip("macros are only supported when running tests for the host platform")
+        #endif
+    }
+
+    func testExplicitTypeAnnotations() throws {
+        #if canImport(DefaultCodableMacros)
+            assertMacroExpansion(
+                """
+                @DefaultCodable
+                struct Foo: Codable {
+                    var numbers: [Int] = [1, 2, 3]
+                    var mapping: [String: Int] = [:]
+                }
+                """,
+                expandedSource: """
+                struct Foo: Codable {
+                    var numbers: [Int] = [1, 2, 3]
+                    var mapping: [String: Int] = [:]
+
+                    enum CodingKeys: String, CodingKey {
+                        case numbers
+                        case mapping
+                    }
+
+                    init(from decoder: Decoder) throws {
+                        let container = try decoder.container(keyedBy: CodingKeys.self)
+                        self.numbers = try container.decodeIfPresent([Int].self, forKey: .numbers) ?? [1, 2, 3]
+                        self.mapping = try container.decodeIfPresent([String: Int].self, forKey: .mapping) ?? [:]
+                    }
+                }
+                """,
+                macros: testMacros
+            )
+        #else
+            throw XCTSkip("macros are only supported when running tests for the host platform")
+        #endif
+    }
 }


### PR DESCRIPTION
## Summary
- expand test coverage for DefaultCodable macro
  - add literal type inference test
  - add explicit type annotation test

## Testing
- `swift test` *(fails: HTTP 403 cloning swift-syntax)*

------
https://chatgpt.com/codex/tasks/task_e_6840b7df351c8325a33e2d3302952078